### PR TITLE
Depend on the generic-comparability system in the test system

### DIFF
--- a/generic-comparability.asd
+++ b/generic-comparability.asd
@@ -17,7 +17,8 @@
   :description "Generic-Comparability test suite"
   :version "1.0.1"
   :depends-on (#:alexandria
-               #:fiveam)
+               #:fiveam
+               #:generic-comparability)
   :license "LLGPL"
   :author "Paul Nathan"
   :components ((:file "generic-comparability-test")))


### PR DESCRIPTION
In order to address http://report.quicklisp.org/2018-01-16/failure-report/generic-comparability.html#generic-comparability-test

See http://blog.quicklisp.org/2018/01/build-failures-with-asdf-331.html for further context